### PR TITLE
Add CSV export utility for volume differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# -
+# Futures Volume Arbitrage Toolkit
+
+This project provides utilities for comparing 24 hour futures quote volume across Bybit and Binance. It includes both a command line helper and a Tkinter-based desktop GUI that can be used to highlight large discrepancies that may uncover arbitrage opportunities.
+
+## Features
+
+- Reusable library functions for downloading Bybit and Binance quote volume statistics
+- Offline fallback snapshot so the toolkit continues to work in environments without external network access
+- Command line interface for quick inspection of the largest discrepancies
+- Cross-platform Tkinter GUI with adjustable refresh interval and auto-refresh option
+
+## Usage
+
+### Command line comparison
+
+Run the CLI helper to print the symbols with the largest absolute volume gap:
+
+```bash
+python scripts/arbitrage_volume.py --limit 10 --threshold 50000000
+```
+
+### Exporting results for review
+
+To download the comparison output for spreadsheets or manual audits, export it as a CSV file:
+
+```bash
+python scripts/download_volumes.py --output data/volume_differences.csv --limit 25 --threshold 10000000
+```
+
+The command above creates `data/volume_differences.csv` with columns for the symbol, each exchange's quote volume, the absolute difference, and the gap ratio. Use `--overwrite` if you would like to replace an existing file.
+
+### GUI dashboard
+
+```bash
+python scripts/arbitrage_gui.py
+```
+
+When the execution environment blocks outbound network access the toolkit automatically falls back to a bundled volume snapshot. The GUI displays the fallback data just like live data, and the CLI prints a warning describing the situation.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Futures Volume Arbitrage Toolkit
 
-This project provides utilities for comparing 24 hour futures quote volume across Bybit and Binance. It includes both a command line helper and a Tkinter-based desktop GUI that can be used to highlight large discrepancies that may uncover arbitrage opportunities.
+This project provides utilities for comparing 24 hour futures quote volume across Bybit and Binance and for monitoring live arbitrage opportunities. It includes command line helpers, a Japanese-localised Tkinter desktop GUI, and a real-time WebSocket listener that flags profitable spreads for the configured symbols.
 
 ## Features
 
 - Reusable library functions for downloading Bybit and Binance quote volume statistics
-- Offline fallback snapshot so the toolkit continues to work in environments without external network access
 - Command line interface for quick inspection of the largest discrepancies
-- Cross-platform Tkinter GUI with adjustable refresh interval and auto-refresh option
+- Cross-platform Tkinter GUI with Japanese labels, adjustable refresh interval, and auto-refresh option
+- Real-time WebSocket listener that focuses on user-specified symbols and prints arbitrage alerts
+- Offline fallback snapshot so the toolkit continues to work in environments without external network access
 
 ## Usage
 
@@ -36,3 +37,23 @@ python scripts/arbitrage_gui.py
 ```
 
 When the execution environment blocks outbound network access the toolkit automatically falls back to a bundled volume snapshot. The GUI displays the fallback data just like live data, and the CLI prints a warning describing the situation.
+
+### Real-time spread detection
+
+Install the optional `websockets` package (``pip install websockets``) to enable real-time feeds. When the dependency or network access is unavailable, run the tool with `--offline` to generate realistic simulated data.
+
+```bash
+python scripts/realtime_arbitrage.py --symbols BTCUSDT,ETHUSDT --spread 5 --percent 0.05
+```
+
+- `--symbols`: Comma separated list of symbols to monitor (default: `BTCUSDT,ETHUSDT`).
+- `--spread`: Minimum absolute spread (USDT) required to emit a signal.
+- `--percent`: Minimum profit ratio (in percent) required to emit a signal.
+- `--offline`: Switch to deterministic simulated prices when WebSocket connectivity is unavailable.
+
+Example output (in Japanese):
+
+```
+2024-01-01 12:34:56 INFO 監視開始: シンボル=BTCUSDT,ETHUSDT, 最小差額=5.0000, 最小利幅=0.050% (リアルタイム)
+2024-01-01 12:34:58 INFO シグナル検出: [2024-01-01 12:34:58] BTCUSDT: binanceで買い bybitで売り | 差額 5.1234 USDT (0.051%)
+```

--- a/arbitrage/__init__.py
+++ b/arbitrage/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for comparing futures market volumes across exchanges."""
+
+from .fetch import ExchangeVolume, fetch_exchange_volumes
+from .volume import VolumeDifference, calculate_volume_differences
+
+__all__ = [
+    "ExchangeVolume",
+    "calculate_volume_differences",
+    "VolumeDifference",
+    "fetch_exchange_volumes",
+]

--- a/arbitrage/__init__.py
+++ b/arbitrage/__init__.py
@@ -1,11 +1,15 @@
 """Utilities for comparing futures market volumes across exchanges."""
 
 from .fetch import ExchangeVolume, fetch_exchange_volumes
+from .realtime import RealTimeArbitrage, RealTimePriceFeed, SpreadSignal
 from .volume import VolumeDifference, calculate_volume_differences
 
 __all__ = [
     "ExchangeVolume",
     "calculate_volume_differences",
+    "RealTimeArbitrage",
+    "RealTimePriceFeed",
+    "SpreadSignal",
     "VolumeDifference",
     "fetch_exchange_volumes",
 ]

--- a/arbitrage/exchanges/binance.py
+++ b/arbitrage/exchanges/binance.py
@@ -1,0 +1,38 @@
+"""Utilities for retrieving futures volume data from Binance's public API."""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Dict, Iterable
+
+_LOGGER = logging.getLogger(__name__)
+
+_API_URL = "https://fapi.binance.com/fapi/v1/ticker/24hr"
+
+
+def _request_tickers(timeout: float = 10.0) -> Iterable[dict]:
+    """Return the raw 24h statistics for all USDT-margined futures symbols."""
+
+    with urllib.request.urlopen(_API_URL, timeout=timeout) as response:
+        payload = json.load(response)
+    if not isinstance(payload, list):
+        raise RuntimeError("Unexpected response from Binance futures API")
+    return payload
+
+
+def get_symbol_volumes(timeout: float = 10.0) -> Dict[str, float]:
+    """Fetch 24h quote volume for USDT-margined perpetual contracts on Binance."""
+
+    volumes: Dict[str, float] = {}
+    for ticker in _request_tickers(timeout=timeout):
+        symbol = ticker.get("symbol")
+        if not symbol:
+            continue
+        volume = ticker.get("quoteVolume")
+        try:
+            volumes[symbol] = float(volume)
+        except (TypeError, ValueError):
+            _LOGGER.debug("Skipping Binance symbol %s with invalid quote volume %r", symbol, volume)
+    return volumes

--- a/arbitrage/exchanges/bybit.py
+++ b/arbitrage/exchanges/bybit.py
@@ -1,0 +1,46 @@
+"""Utilities for retrieving volume data from Bybit's public API."""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+from typing import Dict, Iterable
+
+_LOGGER = logging.getLogger(__name__)
+
+_API_URL = "https://api.bybit.com/v5/market/tickers"
+
+
+def _request_tickers(timeout: float = 10.0) -> Iterable[dict]:
+    """Return the raw ticker payload from Bybit."""
+
+    url = f"{_API_URL}?{urllib.parse.urlencode({'category': 'linear'})}"
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        payload = json.load(response)
+    if payload.get("retCode") != 0:
+        raise RuntimeError(f"Bybit API error: {payload.get('retCode')} {payload.get('retMsg')}")
+    result = payload.get("result", {})
+    return result.get("list", [])
+
+
+def get_symbol_volumes(timeout: float = 10.0) -> Dict[str, float]:
+    """Fetch 24h quote volume for all linear futures symbols on Bybit.
+
+    Returns a mapping ``symbol -> quote volume``.
+    """
+
+    volumes: Dict[str, float] = {}
+    for ticker in _request_tickers(timeout=timeout):
+        symbol = ticker.get("symbol")
+        if not symbol:
+            continue
+        turnover = ticker.get("turnover24h")
+        try:
+            volume = float(turnover)
+        except (TypeError, ValueError):
+            _LOGGER.debug("Skipping Bybit symbol %s with invalid turnover %r", symbol, turnover)
+            continue
+        volumes[symbol] = volume
+    return volumes

--- a/arbitrage/fetch.py
+++ b/arbitrage/fetch.py
@@ -1,0 +1,55 @@
+"""Helpers for fetching and combining exchange volume data."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional
+from urllib.error import URLError
+
+from .exchanges import binance, bybit
+from . import offline
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ExchangeVolume:
+    """24 hour quote volume for a single symbol on an exchange."""
+
+    exchange: str
+    symbol: str
+    quote_volume: float
+
+
+ExchangeVolumeMap = Mapping[str, float]
+
+
+def fetch_exchange_volumes(
+    *,
+    exchanges: Iterable[str] = ("bybit", "binance"),
+    timeout: float = 10.0,
+) -> Dict[str, ExchangeVolumeMap]:
+    """Fetch symbol volume mappings for the requested exchanges."""
+
+    data: Dict[str, ExchangeVolumeMap] = {}
+    for name in exchanges:
+        if name.lower() == "bybit":
+            data["bybit"] = _load_with_fallback(
+                lambda: bybit.get_symbol_volumes(timeout=timeout), offline.BYBIT_SAMPLE
+            )
+        elif name.lower() == "binance":
+            data["binance"] = _load_with_fallback(
+                lambda: binance.get_symbol_volumes(timeout=timeout), offline.BINANCE_SAMPLE
+            )
+        else:
+            raise ValueError(f"Unsupported exchange: {name}")
+    return data
+
+
+def _load_with_fallback(loader, fallback: ExchangeVolumeMap) -> ExchangeVolumeMap:
+    try:
+        return loader()
+    except URLError as exc:
+        _LOGGER.warning("Falling back to offline sample data due to network error: %s", exc)
+        return fallback

--- a/arbitrage/offline.py
+++ b/arbitrage/offline.py
@@ -1,0 +1,19 @@
+"""Offline fallback data for development environments without internet access."""
+
+from __future__ import annotations
+
+BYBIT_SAMPLE = {
+    "BTCUSDT": 3_250_000_000.0,
+    "ETHUSDT": 1_550_000_000.0,
+    "XRPUSDT": 320_000_000.0,
+    "SOLUSDT": 410_000_000.0,
+    "DOGEUSDT": 190_000_000.0,
+}
+
+BINANCE_SAMPLE = {
+    "BTCUSDT": 3_100_000_000.0,
+    "ETHUSDT": 1_600_000_000.0,
+    "XRPUSDT": 280_000_000.0,
+    "SOLUSDT": 450_000_000.0,
+    "DOGEUSDT": 210_000_000.0,
+}

--- a/arbitrage/realtime.py
+++ b/arbitrage/realtime.py
@@ -1,0 +1,270 @@
+"""Realtime pricing utilities for arbitrage monitoring.
+
+The module provides helpers to subscribe to Bybit/Binance book tickers via
+WebSocket (with graceful offline fallbacks) and detect actionable spreads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import math
+import random
+import time
+from dataclasses import dataclass
+from typing import AsyncIterator, Dict, List, Sequence
+
+_LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency is checked at runtime
+    import websockets
+except Exception:  # pragma: no cover - any error leads to offline mode
+    websockets = None  # type: ignore
+
+
+@dataclass(slots=True)
+class PriceUpdate:
+    """Represents a single best bid/ask update for a symbol on an exchange."""
+
+    exchange: str
+    symbol: str
+    bid: float
+    ask: float
+    timestamp: float
+
+
+@dataclass(slots=True)
+class SpreadSignal:
+    """An arbitrage opportunity detected between two exchanges."""
+
+    symbol: str
+    buy_exchange: str
+    sell_exchange: str
+    spread: float
+    spread_pct: float
+    timestamp: float
+
+
+class RealTimePriceFeed:
+    """Stream best bid/ask data from exchanges or an offline simulator."""
+
+    def __init__(
+        self,
+        symbols: Sequence[str],
+        *,
+        reconnect_delay: float = 5.0,
+        offline: bool = False,
+    ) -> None:
+        self.symbols = [symbol.upper() for symbol in symbols]
+        self.reconnect_delay = max(reconnect_delay, 1.0)
+        self.offline = offline or websockets is None
+
+    async def updates(self) -> AsyncIterator[PriceUpdate]:
+        if not self.symbols:
+            return
+        if self.offline:
+            async for update in self._offline_stream():
+                yield update
+            return
+
+        queue: asyncio.Queue[PriceUpdate] = asyncio.Queue()
+        tasks = [
+            asyncio.create_task(self._run_binance(queue)),
+            asyncio.create_task(self._run_bybit(queue)),
+        ]
+        try:
+            while True:
+                update = await queue.get()
+                yield update
+        finally:
+            for task in tasks:
+                task.cancel()
+                with contextlib.suppress(Exception):
+                    await task
+
+    async def _offline_stream(self) -> AsyncIterator[PriceUpdate]:
+        base_prices = {symbol: 20000.0 + i * 1000 for i, symbol in enumerate(self.symbols)}
+        while True:
+            now = time.time()
+            for exchange in ("binance", "bybit"):
+                for idx, symbol in enumerate(self.symbols):
+                    drift = math.sin(now / 30 + idx) * 10
+                    noise = random.uniform(-2, 2)
+                    mid = base_prices[symbol] + drift + noise
+                    spread = random.uniform(0.5, 2.5)
+                    if exchange == "binance":
+                        mid += random.uniform(-1, 1)
+                    else:
+                        mid += random.uniform(-1, 1)
+                    yield PriceUpdate(
+                        exchange=exchange,
+                        symbol=symbol,
+                        bid=mid - spread / 2,
+                        ask=mid + spread / 2,
+                        timestamp=now,
+                    )
+            await asyncio.sleep(1.0)
+
+    async def _run_binance(self, queue: asyncio.Queue[PriceUpdate]) -> None:
+        if not self.symbols:
+            return
+
+        stream_names = "/".join(f"{symbol.lower()}@bookTicker" for symbol in self.symbols)
+        url = f"wss://fstream.binance.com/stream?streams={stream_names}"
+
+        while True:
+            try:
+                if websockets is None:  # pragma: no cover - safety net
+                    return
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    async for raw in ws:
+                        try:
+                            payload = json.loads(raw)
+                        except json.JSONDecodeError:
+                            _LOGGER.debug("Binance WS invalid JSON: %s", raw)
+                            continue
+                        data = payload.get("data") if isinstance(payload, dict) else None
+                        if not isinstance(data, dict):
+                            continue
+                        symbol = data.get("s") or data.get("symbol")
+                        bid = data.get("b") or data.get("bidPrice")
+                        ask = data.get("a") or data.get("askPrice")
+                        timestamp = data.get("E") or time.time() * 1000
+                        try:
+                            update = PriceUpdate(
+                                exchange="binance",
+                                symbol=str(symbol).upper(),
+                                bid=float(bid),
+                                ask=float(ask),
+                                timestamp=float(timestamp) / 1000.0,
+                            )
+                        except (TypeError, ValueError):
+                            continue
+                        await queue.put(update)
+            except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+                raise
+            except Exception as exc:
+                _LOGGER.warning("Binance WS error: %s", exc)
+                await asyncio.sleep(self.reconnect_delay)
+
+    async def _run_bybit(self, queue: asyncio.Queue[PriceUpdate]) -> None:
+        if not self.symbols:
+            return
+
+        url = "wss://stream.bybit.com/v5/public/linear"
+        subscribe = {
+            "op": "subscribe",
+            "args": [f"tickers.{symbol.upper()}" for symbol in self.symbols],
+        }
+
+        while True:
+            try:
+                if websockets is None:  # pragma: no cover
+                    return
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(subscribe))
+                    async for raw in ws:
+                        try:
+                            payload = json.loads(raw)
+                        except json.JSONDecodeError:
+                            _LOGGER.debug("Bybit WS invalid JSON: %s", raw)
+                            continue
+                        topic = payload.get("topic")
+                        if not isinstance(topic, str) or not topic.startswith("tickers."):
+                            continue
+                        data = payload.get("data")
+                        if isinstance(data, list):
+                            candidates = data
+                        elif isinstance(data, dict):
+                            candidates = [data]
+                        else:
+                            continue
+                        for entry in candidates:
+                            symbol = entry.get("symbol") or topic.split(".")[-1]
+                            bid = entry.get("bid1Price") or entry.get("bidPrice")
+                            ask = entry.get("ask1Price") or entry.get("askPrice")
+                            timestamp = entry.get("ts") or entry.get("timestamp") or time.time() * 1000
+                            try:
+                                update = PriceUpdate(
+                                    exchange="bybit",
+                                    symbol=str(symbol).upper(),
+                                    bid=float(bid),
+                                    ask=float(ask),
+                                    timestamp=float(timestamp) / 1000.0,
+                                )
+                            except (TypeError, ValueError):
+                                continue
+                            await queue.put(update)
+            except asyncio.CancelledError:  # pragma: no cover
+                raise
+            except Exception as exc:
+                _LOGGER.warning("Bybit WS error: %s", exc)
+                await asyncio.sleep(self.reconnect_delay)
+
+
+class RealTimeArbitrage:
+    """Detect arbitrage spreads from a realtime price feed."""
+
+    def __init__(
+        self,
+        symbols: Sequence[str],
+        *,
+        absolute_threshold: float = 0.0,
+        pct_threshold: float = 0.0,
+        offline: bool = False,
+    ) -> None:
+        self.feed = RealTimePriceFeed(symbols, offline=offline)
+        self.absolute_threshold = max(absolute_threshold, 0.0)
+        self.pct_threshold = max(pct_threshold, 0.0)
+        self._latest: Dict[str, Dict[str, PriceUpdate]] = {symbol.upper(): {} for symbol in symbols}
+
+    async def signals(self) -> AsyncIterator[SpreadSignal]:
+        async for update in self.feed.updates():
+            self._latest.setdefault(update.symbol, {})[update.exchange] = update
+            opportunities = self._evaluate_symbol(update.symbol)
+            for signal in opportunities:
+                yield signal
+
+    def _evaluate_symbol(self, symbol: str) -> List[SpreadSignal]:
+        symbol_updates = self._latest.get(symbol.upper())
+        if not symbol_updates or len(symbol_updates) < 2:
+            return []
+
+        results: List[SpreadSignal] = []
+        exchanges = list(symbol_updates.keys())
+        for buy_exchange in exchanges:
+            buy_update = symbol_updates[buy_exchange]
+            for sell_exchange in exchanges:
+                if buy_exchange == sell_exchange:
+                    continue
+                sell_update = symbol_updates[sell_exchange]
+                spread = sell_update.bid - buy_update.ask
+                if spread <= 0:
+                    continue
+                mid = (sell_update.bid + buy_update.ask) / 2
+                spread_pct = spread / mid if mid else 0.0
+                if spread < self.absolute_threshold:
+                    continue
+                if spread_pct < self.pct_threshold:
+                    continue
+                results.append(
+                    SpreadSignal(
+                        symbol=symbol.upper(),
+                        buy_exchange=buy_exchange,
+                        sell_exchange=sell_exchange,
+                        spread=spread,
+                        spread_pct=spread_pct,
+                        timestamp=max(buy_update.timestamp, sell_update.timestamp),
+                    )
+                )
+        return results
+
+
+__all__ = [
+    "PriceUpdate",
+    "RealTimeArbitrage",
+    "RealTimePriceFeed",
+    "SpreadSignal",
+]

--- a/arbitrage/volume.py
+++ b/arbitrage/volume.py
@@ -1,0 +1,51 @@
+"""Utilities for comparing symbol volumes across exchanges."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+
+@dataclass
+class VolumeDifference:
+    """Represents the absolute and relative difference between two volumes."""
+
+    symbol: str
+    base_volume: float
+    quote_volume: float
+    difference: float
+    ratio: float
+
+
+def calculate_volume_differences(
+    base_volumes: Mapping[str, float],
+    quote_volumes: Mapping[str, float],
+    *,
+    min_difference: float = 0.0,
+    limit: int | None = None,
+) -> List[VolumeDifference]:
+    """Return the top symbols ordered by absolute volume difference."""
+
+    diffs: List[VolumeDifference] = []
+    for symbol, base_volume in base_volumes.items():
+        quote_volume = quote_volumes.get(symbol)
+        if quote_volume is None:
+            continue
+        diff = abs(base_volume - quote_volume)
+        if diff < min_difference:
+            continue
+        ratio = diff / base_volume if base_volume else float("inf")
+        diffs.append(
+            VolumeDifference(
+                symbol=symbol,
+                base_volume=base_volume,
+                quote_volume=quote_volume,
+                difference=diff,
+                ratio=ratio,
+            )
+        )
+
+    diffs.sort(key=lambda item: item.difference, reverse=True)
+    if limit is not None:
+        diffs = diffs[:limit]
+    return diffs

--- a/scripts/arbitrage_gui.py
+++ b/scripts/arbitrage_gui.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 class ArbitrageApp:
     def __init__(self, master: tk.Tk) -> None:
         self.master = master
-        master.title("Futures Volume Arbitrage Monitor")
+        master.title("出来高アービトラージモニター")
         master.geometry("900x500")
 
         self._refresh_job: Optional[str] = None
@@ -30,7 +30,7 @@ class ArbitrageApp:
         self.limit_var = tk.StringVar(value="15")
         self.threshold_var = tk.StringVar(value="0")
         self.interval_var = tk.StringVar(value="30")
-        self.status_var = tk.StringVar(value="Ready")
+        self.status_var = tk.StringVar(value="待機中")
 
         self._build_controls(master)
         self._build_table(master)
@@ -41,30 +41,30 @@ class ArbitrageApp:
         frame = ttk.Frame(master, padding=10)
         frame.pack(side=tk.TOP, fill=tk.X)
 
-        ttk.Label(frame, text="Top N:").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(frame, text="表示件数:").grid(row=0, column=0, sticky=tk.W)
         ttk.Entry(frame, width=6, textvariable=self.limit_var).grid(row=0, column=1, padx=(0, 12))
 
-        ttk.Label(frame, text="Min diff (USDT):").grid(row=0, column=2, sticky=tk.W)
+        ttk.Label(frame, text="最小差額 (USDT):").grid(row=0, column=2, sticky=tk.W)
         ttk.Entry(frame, width=10, textvariable=self.threshold_var).grid(row=0, column=3, padx=(0, 12))
 
-        ttk.Label(frame, text="Refresh (s):").grid(row=0, column=4, sticky=tk.W)
+        ttk.Label(frame, text="更新間隔 (秒):").grid(row=0, column=4, sticky=tk.W)
         ttk.Entry(frame, width=6, textvariable=self.interval_var).grid(row=0, column=5, padx=(0, 12))
 
-        refresh_btn = ttk.Button(frame, text="Refresh", command=self.refresh)
+        refresh_btn = ttk.Button(frame, text="今すぐ更新", command=self.refresh)
         refresh_btn.grid(row=0, column=6)
 
-        auto_btn = ttk.Button(frame, text="Start Auto Refresh", command=self.toggle_auto_refresh)
+        auto_btn = ttk.Button(frame, text="自動更新開始", command=self.toggle_auto_refresh)
         auto_btn.grid(row=0, column=7, padx=(12, 0))
         self.auto_button = auto_btn
 
     def _build_table(self, master: tk.Tk) -> None:
         columns = ("symbol", "bybit", "binance", "diff", "ratio")
         tree = ttk.Treeview(master, columns=columns, show="headings", height=18)
-        tree.heading("symbol", text="Symbol")
-        tree.heading("bybit", text="Bybit Quote Volume")
-        tree.heading("binance", text="Binance Quote Volume")
-        tree.heading("diff", text="Difference")
-        tree.heading("ratio", text="Ratio")
+        tree.heading("symbol", text="シンボル")
+        tree.heading("bybit", text="Bybit 出来高")
+        tree.heading("binance", text="Binance 出来高")
+        tree.heading("diff", text="差分")
+        tree.heading("ratio", text="比率")
 
         tree.column("symbol", width=120, anchor=tk.W)
         tree.column("bybit", width=200, anchor=tk.E)
@@ -97,7 +97,7 @@ class ArbitrageApp:
         limit = self._parse_int(self.limit_var.get(), default=10)
         threshold = self._parse_float(self.threshold_var.get(), default=0.0)
 
-        self.status_var.set("Fetching volumes…")
+        self.status_var.set("出来高を取得中…")
         self.master.update_idletasks()
         try:
             volumes = fetch_exchange_volumes()
@@ -109,7 +109,7 @@ class ArbitrageApp:
             )
         except Exception as exc:  # pragma: no cover - safety net for GUI
             logging.exception("Failed to refresh data")
-            self.status_var.set(f"Error: {exc}")
+            self.status_var.set(f"エラー: {exc}")
             return
 
         self.tree.delete(*self.tree.get_children())
@@ -125,17 +125,17 @@ class ArbitrageApp:
                     f"{item.ratio:,.2%}" if not math.isinf(item.ratio) else "∞",
                 ),
             )
-        self.status_var.set(f"Last update succeeded with {len(diffs)} symbols shown")
+        self.status_var.set(f"{len(diffs)} 件のシンボルを更新しました")
 
     def toggle_auto_refresh(self) -> None:
         if self._refresh_job is None:
             interval = max(self._parse_int(self.interval_var.get(), default=30), 5)
-            self.auto_button.config(text="Stop Auto Refresh")
+            self.auto_button.config(text="自動更新停止")
             self._schedule_refresh(interval)
-            self.status_var.set(f"Auto refresh every {interval} seconds")
+            self.status_var.set(f"{interval} 秒ごとに自動更新中")
         else:
             self._cancel_refresh()
-            self.status_var.set("Auto refresh stopped")
+            self.status_var.set("自動更新を停止しました")
 
     def _schedule_refresh(self, interval: int) -> None:
         self.refresh()
@@ -145,7 +145,7 @@ class ArbitrageApp:
         if self._refresh_job is not None:
             self.master.after_cancel(self._refresh_job)
             self._refresh_job = None
-            self.auto_button.config(text="Start Auto Refresh")
+            self.auto_button.config(text="自動更新開始")
 
 
 def main() -> int:

--- a/scripts/arbitrage_gui.py
+++ b/scripts/arbitrage_gui.py
@@ -1,0 +1,159 @@
+"""Tkinter GUI for monitoring futures volume differences between exchanges."""
+
+from __future__ import annotations
+
+import logging
+import math
+import pathlib
+import sys
+import tkinter as tk
+from tkinter import ttk
+from typing import Optional
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from arbitrage import calculate_volume_differences, fetch_exchange_volumes
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+class ArbitrageApp:
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        master.title("Futures Volume Arbitrage Monitor")
+        master.geometry("900x500")
+
+        self._refresh_job: Optional[str] = None
+
+        self.limit_var = tk.StringVar(value="15")
+        self.threshold_var = tk.StringVar(value="0")
+        self.interval_var = tk.StringVar(value="30")
+        self.status_var = tk.StringVar(value="Ready")
+
+        self._build_controls(master)
+        self._build_table(master)
+        self._build_status(master)
+
+    # UI builders ---------------------------------------------------------
+    def _build_controls(self, master: tk.Tk) -> None:
+        frame = ttk.Frame(master, padding=10)
+        frame.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(frame, text="Top N:").grid(row=0, column=0, sticky=tk.W)
+        ttk.Entry(frame, width=6, textvariable=self.limit_var).grid(row=0, column=1, padx=(0, 12))
+
+        ttk.Label(frame, text="Min diff (USDT):").grid(row=0, column=2, sticky=tk.W)
+        ttk.Entry(frame, width=10, textvariable=self.threshold_var).grid(row=0, column=3, padx=(0, 12))
+
+        ttk.Label(frame, text="Refresh (s):").grid(row=0, column=4, sticky=tk.W)
+        ttk.Entry(frame, width=6, textvariable=self.interval_var).grid(row=0, column=5, padx=(0, 12))
+
+        refresh_btn = ttk.Button(frame, text="Refresh", command=self.refresh)
+        refresh_btn.grid(row=0, column=6)
+
+        auto_btn = ttk.Button(frame, text="Start Auto Refresh", command=self.toggle_auto_refresh)
+        auto_btn.grid(row=0, column=7, padx=(12, 0))
+        self.auto_button = auto_btn
+
+    def _build_table(self, master: tk.Tk) -> None:
+        columns = ("symbol", "bybit", "binance", "diff", "ratio")
+        tree = ttk.Treeview(master, columns=columns, show="headings", height=18)
+        tree.heading("symbol", text="Symbol")
+        tree.heading("bybit", text="Bybit Quote Volume")
+        tree.heading("binance", text="Binance Quote Volume")
+        tree.heading("diff", text="Difference")
+        tree.heading("ratio", text="Ratio")
+
+        tree.column("symbol", width=120, anchor=tk.W)
+        tree.column("bybit", width=200, anchor=tk.E)
+        tree.column("binance", width=200, anchor=tk.E)
+        tree.column("diff", width=160, anchor=tk.E)
+        tree.column("ratio", width=120, anchor=tk.E)
+
+        tree.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=10, pady=(0, 10))
+        self.tree = tree
+
+    def _build_status(self, master: tk.Tk) -> None:
+        frame = ttk.Frame(master, padding=10)
+        frame.pack(side=tk.BOTTOM, fill=tk.X)
+        ttk.Label(frame, textvariable=self.status_var).pack(side=tk.LEFT)
+
+    # Refresh logic -------------------------------------------------------
+    def _parse_int(self, value: str, *, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _parse_float(self, value: str, *, default: float) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    def refresh(self) -> None:
+        limit = self._parse_int(self.limit_var.get(), default=10)
+        threshold = self._parse_float(self.threshold_var.get(), default=0.0)
+
+        self.status_var.set("Fetching volumes…")
+        self.master.update_idletasks()
+        try:
+            volumes = fetch_exchange_volumes()
+            diffs = calculate_volume_differences(
+                volumes["bybit"],
+                volumes["binance"],
+                min_difference=threshold,
+                limit=limit,
+            )
+        except Exception as exc:  # pragma: no cover - safety net for GUI
+            logging.exception("Failed to refresh data")
+            self.status_var.set(f"Error: {exc}")
+            return
+
+        self.tree.delete(*self.tree.get_children())
+        for item in diffs:
+            self.tree.insert(
+                "",
+                tk.END,
+                values=(
+                    item.symbol,
+                    f"{item.base_volume:,.2f}",
+                    f"{item.quote_volume:,.2f}",
+                    f"{item.difference:,.2f}",
+                    f"{item.ratio:,.2%}" if not math.isinf(item.ratio) else "∞",
+                ),
+            )
+        self.status_var.set(f"Last update succeeded with {len(diffs)} symbols shown")
+
+    def toggle_auto_refresh(self) -> None:
+        if self._refresh_job is None:
+            interval = max(self._parse_int(self.interval_var.get(), default=30), 5)
+            self.auto_button.config(text="Stop Auto Refresh")
+            self._schedule_refresh(interval)
+            self.status_var.set(f"Auto refresh every {interval} seconds")
+        else:
+            self._cancel_refresh()
+            self.status_var.set("Auto refresh stopped")
+
+    def _schedule_refresh(self, interval: int) -> None:
+        self.refresh()
+        self._refresh_job = self.master.after(interval * 1000, lambda: self._schedule_refresh(interval))
+
+    def _cancel_refresh(self) -> None:
+        if self._refresh_job is not None:
+            self.master.after_cancel(self._refresh_job)
+            self._refresh_job = None
+            self.auto_button.config(text="Start Auto Refresh")
+
+
+def main() -> int:
+    root = tk.Tk()
+    app = ArbitrageApp(root)
+    root.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/arbitrage_volume.py
+++ b/scripts/arbitrage_volume.py
@@ -1,0 +1,55 @@
+"""Command line utility for inspecting volume differences."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import sys
+from typing import Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from arbitrage import calculate_volume_differences, fetch_exchange_volumes
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=10, help="Number of symbols to display")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        help="Minimum absolute difference in quote volume",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        volumes = fetch_exchange_volumes()
+    except Exception as exc:
+        logging.error("Failed to fetch volumes: %s", exc)
+        return 1
+    diffs = calculate_volume_differences(
+        volumes["bybit"],
+        volumes["binance"],
+        min_difference=args.threshold,
+        limit=args.limit,
+    )
+
+    for item in diffs:
+        print(
+            f"{item.symbol:15s} Bybit: {item.base_volume:15.2f} | Binance: {item.quote_volume:15.2f} | "
+            f"Diff: {item.difference:12.2f}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_volumes.py
+++ b/scripts/download_volumes.py
@@ -1,0 +1,92 @@
+"""Export Bybit/Binance volume differences to a CSV file."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import pathlib
+import sys
+from typing import Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from arbitrage import calculate_volume_differences, fetch_exchange_volumes
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("volume_differences.csv"),
+        help="Destination CSV file for the exported data.",
+    )
+    parser.add_argument("--limit", type=int, default=50, help="Maximum number of rows to export.")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        help="Minimum absolute quote volume difference (USDT) to include.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+    return parser.parse_args(argv)
+
+
+def export_differences(args: argparse.Namespace) -> int:
+    try:
+        volumes = fetch_exchange_volumes()
+    except Exception as exc:
+        logger.error("Failed to fetch exchange volumes: %s", exc)
+        return 1
+
+    diffs = calculate_volume_differences(
+        volumes["bybit"],
+        volumes["binance"],
+        min_difference=args.threshold,
+        limit=args.limit,
+    )
+
+    if not diffs:
+        logger.warning("No symbols matched the requested criteria.")
+
+    output_path = args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists() and not args.overwrite:
+        logger.error("Output file %s already exists. Use --overwrite to replace it.", output_path)
+        return 1
+
+    with output_path.open("w", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerow(["symbol", "bybit_quote_volume", "binance_quote_volume", "difference", "ratio"])
+        for diff in diffs:
+            writer.writerow(
+                [
+                    diff.symbol,
+                    f"{diff.base_volume:.6f}",
+                    f"{diff.quote_volume:.6f}",
+                    f"{diff.difference:.6f}",
+                    f"{diff.ratio:.6f}",
+                ]
+            )
+
+    logger.info("Exported %d rows to %s", len(diffs), output_path)
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args(argv)
+    return export_differences(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/realtime_arbitrage.py
+++ b/scripts/realtime_arbitrage.py
@@ -1,0 +1,106 @@
+"""リアルタイムで裁定機会を通知するCLIツール."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import pathlib
+import sys
+import textwrap
+from datetime import datetime
+from typing import Sequence
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from arbitrage import RealTimeArbitrage
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _parse_symbols(value: str) -> Sequence[str]:
+    symbols = [item.strip().upper() for item in value.split(",") if item.strip()]
+    if not symbols:
+        raise argparse.ArgumentTypeError("少なくとも1つのシンボルを指定してください")
+    return symbols
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bybit/Binance の最良気配を WebSocket 経由で取得し、裁定シグナルを通知します。",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """例:
+              python scripts/realtime_arbitrage.py --symbols BTCUSDT,ETHUSDT --spread 5 --percent 0.05
+            """
+        ),
+    )
+    parser.add_argument(
+        "--symbols",
+        type=_parse_symbols,
+        default=["BTCUSDT", "ETHUSDT"],
+        help="監視する通貨ペアをカンマ区切りで指定します (例: BTCUSDT,ETHUSDT)",
+    )
+    parser.add_argument(
+        "--spread",
+        type=float,
+        default=1.0,
+        help="売り買いの差額がこのUSDT以上でシグナルを通知します",
+    )
+    parser.add_argument(
+        "--percent",
+        type=float,
+        default=0.0,
+        help="利幅がこの割合(%)以上の場合に通知します",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="ネットワークに接続できない環境向けのシミュレーションモード",
+    )
+    return parser
+
+
+def format_signal(signal) -> str:
+    timestamp = datetime.fromtimestamp(signal.timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    pct = signal.spread_pct * 100
+    return (
+        f"[{timestamp}] {signal.symbol}: {signal.buy_exchange}で買い {signal.sell_exchange}で売り"
+        f" | 差額 {signal.spread:.4f} USDT ({pct:.3f}%)"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.info(
+        "監視開始: シンボル=%s, 最小差額=%.4f, 最小利幅=%.3f%% (%s)",
+        ",".join(args.symbols),
+        args.spread,
+        args.percent,
+        "オフライン" if args.offline else "リアルタイム",
+    )
+
+    engine = RealTimeArbitrage(
+        args.symbols,
+        absolute_threshold=args.spread,
+        pct_threshold=args.percent / 100,
+        offline=args.offline,
+    )
+
+    async def runner() -> None:
+        async for signal in engine.signals():
+            logging.info("シグナル検出: %s", format_signal(signal))
+
+    try:
+        asyncio.run(runner())
+    except KeyboardInterrupt:
+        logging.info("ユーザーにより終了しました")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a download_volumes CLI helper that exports Bybit/Binance volume gaps as CSV for auditing
- document the new export workflow alongside the existing CLI and GUI instructions

## Testing
- python scripts/download_volumes.py --output /tmp/test_volumes.csv --limit 5 --threshold 0
- python -m compileall arbitrage scripts

------
https://chatgpt.com/codex/tasks/task_e_68d3bf4e2048833184ea0279e454a135